### PR TITLE
Fix broken url duo to failty redirect in backend

### DIFF
--- a/people.md
+++ b/people.md
@@ -5,7 +5,7 @@
 
 These are the people who make it all work. People in **bold** have credentials to run SmokeDetector, including metasmoke integration tokens. People with (RO) after their names are room owners.
 
-If you're wondering who you should talk to about something, [there's a guide for that](/pings).
+If you're wondering who you should talk to about something, [there's a guide for that](/pings/).
 
 <section>
 ## Administrators {#admins}


### PR DESCRIPTION
At the moment, trying to click the link "pings" in the [people](https://charcoal-se.org/people) page results in failure to load the pings page (it just keeps showing people page with the wrong url in the topbar), only after clicking th elink twice, it works.

The reason for this is that we use a "instant page loading plugin" that requests pages before the link is clicked, while this plugin usually works file, it breaks when the actual URL is redirected to an insecure page, and at the moment, for some reason, `https://charcoal-se.org/pings` redirects to `http://charcoal-se.org/pings/`. While we cannot patch the backend to solve this (as this is an issue with the github hosting), we can solve this by making sure this "useless" redirect is avoided.