### PR TITLE
Fix eternal CI failure in pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ _site/
 .asset-cache
 .jekyll-metadata
 .idea
+
+/vendor/
+/ms/
+/smokey/

--- a/script/build
+++ b/script/build
@@ -1,14 +1,16 @@
+#!/bin/bash
+
 for i in "$@"
 do
-case $i in
+  case $i in
     --dev)
-    DEV=YES
-    shift # past argument with no value
-    ;;
+      DEV=YES
+      shift # past argument with no value
+      ;;
     *)
-            # unknown option
-    ;;
-esac
+      # unknown option
+      ;;
+  esac
 done
 
 function force-fetch {
@@ -27,7 +29,7 @@ force-fetch smokey "https://github.com/Charcoal-SE/SmokeDetector.wiki" &
 wait
 
 for file in **/Home.md; do
-    mv "$file" "`dirname "$file"`/index.md"
+  mv "$file" "`dirname "$file"`/index.md"
 done
 
 ./add-front-matter.rb ms/** smokey/** &
@@ -60,10 +62,10 @@ cd assets
 mkdir css images
 
 for file in branding*.css; do
-    cp "$file" css/branding.css
+  cp "$file" css/branding.css
 done
 for file in charcoal*.png; do
-    cp "$file" images/charcoal.png
+  cp "$file" images/charcoal.png
 done
 
 cd ..

--- a/script/build
+++ b/script/build
@@ -2,8 +2,10 @@
 
 # Process environment variables
 if [[ "$TRAVIS_PULL_REQUEST" =~ ^[0-9]+$ ]]; then
-  DEV=YES
   echo "Building pull request #$TRAVIS_PULL_REQUEST, dev mode enabled" >&2
+
+  DEV=YES
+  unset GH_TOKEN TRAVIS_GITHUB_TOKEN
 fi
 
 
@@ -66,7 +68,7 @@ fi
 
 cd _site
 cd assets
-mkdir css images
+mkdir -p css images
 
 for file in branding*.css; do
   cp "$file" css/branding.css

--- a/script/build
+++ b/script/build
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Process environment variables
+if [[ "$TRAVIS_PULL_REQUEST" =~ ^[0-9]+$ ]]; then
+  DEV=YES
+  echo "Building pull request #$TRAVIS_PULL_REQUEST, dev mode enabled" >&2
+fi
+
+
 for i in "$@"
 do
   case $i in

--- a/script/install
+++ b/script/install
@@ -1,14 +1,16 @@
+#!/bin/bash
+
 for i in "$@"
 do
-case $i in
+  case $i in
     --deploy)
-    DEPLOY=YES
-    shift # past argument with no value
-    ;;
+      DEPLOY=YES
+      shift # past argument with no value
+      ;;
     *)
-            # unknown option
-    ;;
-esac
+      # unknown option
+      ;;
+  esac
 done
 
 function force-fetch {

--- a/script/serve
+++ b/script/serve
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 bundle exec jekyll serve --incremental -L


### PR DESCRIPTION
From the [Travis CI documentation][1], we can use environment variables to detect pull requests, and when so, disable pushing. This will prevent PRs from failing the CI for having invalid credentials.

Travis does it right in this case. Secure environment variables aren't available to PRs and can't be used.

[1]: https://docs.travis-ci.com/user/environment-variables/