### PR TITLE
Highlight heading only using :target

### DIFF
--- a/_assets/css/application.scss
+++ b/_assets/css/application.scss
@@ -185,7 +185,7 @@ blockquote {
   }
 }
 
-.hash-target {
+:target {
   box-shadow: 0 0 20px #6B1A00;
   padding: 1px 20px;
 }

--- a/_assets/js/application.coffee
+++ b/_assets/js/application.coffee
@@ -7,11 +7,6 @@ $ ->
     parent: 'html'
 
   $(window).on 'load turbolinks:load', ->
-    $('.hash-target').removeClass 'hash-target'
-
-    if location.hash != ""
-      $(location.hash).parent().addClass 'hash-target'
-
     date = new Date()
     p = (n, length = 2) ->
       n = String n


### PR DESCRIPTION
Fix for issue #44 
I followed the second fix i.e. highlight the heading only, using `:target`.

Here the final output:
![privileges charcoal](https://user-images.githubusercontent.com/16872657/46306096-ec1d1b00-c5d0-11e8-8275-0a15ab17706c.png)
