### PR TITLE
Add teward to disclosure reports

### DIFF
--- a/security.md
+++ b/security.md
@@ -13,5 +13,6 @@ If you'd like to encrypt your email, you can find our PGP key here: <https://met
 ## Acknowledgements
 We'd like to extend special thanks to these people, who have helped us out by reporting security vulnerabilities to us.
 
+ - [teward](https://stackoverflow.com/users/603346/thomas-ward) - improper SQL dump sanitization and handling
  - [NobodyNada](https://stackoverflow.com/users/3476191/nobodynada) - server memory dump disclosure
  - [user12986714](https://stackoverflow.com/users/12986714/user12986714) - SQL injection vulnerability


### PR DESCRIPTION
I helped (internally initially) discover the SQL dumps weren't being sanitized properly prior to being made public.  To that end, we then pushed a rapid fix, and have altered things internally to compensate, however it was still a vulnerability that was discovered and reported and fixed by me when trying to figure out how to make SQL dumps not freeze up Metasmoke.

Just want to add proper acknowledgements.  👍 