### PR TITLE
Update index.md: "It's Dead" time notes for autoreboots.

### DIFF
--- a/pings/index.md
+++ b/pings/index.md
@@ -84,7 +84,7 @@ If all else fails, please ping one of the people with a **bold name** on [this l
 
 If even that fails, panicking is acceptable (but of course, you know where your towel is and will remain calm). Ping ArtOfCode or Undo - they have a few extra tools in metasmoke that may yet be able to resolve the issue.
 
-If Metasmoke is responding with HTTP 503 errors, make sure that it's not around 17:15 UTC - Metasmoke reboots daily around this time to make sure it's not caching writes to the DB or other resources in swap or RAM.  If it is around that time, then wait a few minutes and try again. Otherwise, if Metasmoke is still not responding, check with Undo or Thomas Ward, they will be able to determine if there's something hindering Metasmoke's availability.
+If Metasmoke is responding with HTTP 503 errors, make sure that it's not around 05:15 UTC or 17:15 UTC (give or take an hour for timezones) - Metasmoke reboots daily around this time to make sure it's not caching writes to the DB or other resources in swap or RAM.  If it is around that time, then wait a few minutes and try again. Otherwise, if Metasmoke is still not responding, check with Undo or Thomas Ward, they will be able to determine if there's something hindering Metasmoke's availability.
 </section>
 <section>
 


### PR DESCRIPTION
We have two MS reboot times and because timezones are evil the timeskew from these UTC values is +/- 1 hour.