### PR TITLE
Add info on spam waves to the autoflagging wiki page

### DIFF
--- a/flagging.md
+++ b/flagging.md
@@ -74,11 +74,18 @@ If you'd like more information on the technical side of the system, drop into
 <section>
 ## What are spam waves? {#spam-waves}
 
-Spam waves are a tool that [metasmoke admins](https://charcoal-se.org/smokey/Privileges#admin-ms) have to set SmokeDetector to immediately cast any number of autoflags on detected posts matching pre-set criteria. That includes enough autoflags to immediately delete the post without requiring users to cast flags manually. This feature is separate from blacklisted/watched keywords - an admin must manually configure it in metasmoke.
+Spam waves are a tool that [metasmoke admins](https://charcoal-se.org/smokey/Privileges#admin-ms) have to set SmokeDetector
+to immediately cast any number of autoflags on detected posts matching pre-set criteria. That includes enough autoflags to
+immediately delete the post without requiring users to cast flags manually. This feature is separate from blacklisted/watched
+keywords - an admin must manually configure it in metasmoke.
 
-Additionally, SmokeDetector may use flags from _any_ user account with flagging enabled in metasmoke, regardless of the account’s autoflagging configuration (if any). At this time, it is not possible to opt out of this.
+Additionally, SmokeDetector may use flags from _any_ user account with flagging enabled in metasmoke, regardless of the
+account’s autoflagging configuration (if any). At this time, it is not possible to opt out of this.
 
-If you wish to suggest a new spam wave, ping Makyen or another metasmoke admin for further information on how to proceed. Note that approval from a CM is required for unilateral deletion of posts matching specific criteria. Approval from site moderators is also acceptable for raising flags above the "normal" baseline. This tool is reserved for situations involving a severe influx of spam or extremely abusive content.
+If you wish to suggest a new spam wave, ping Makyen or another metasmoke admin for further information on how to proceed.
+Note that approval from a CM is required for unilateral deletion of posts matching specific criteria. Approval from site
+moderators is also acceptable for raising flags above the "normal" baseline. This tool is reserved for situations involving
+a severe influx of spam or extremely abusive content.
 </section>
 
 <section>

--- a/flagging.md
+++ b/flagging.md
@@ -72,6 +72,16 @@ If you'd like more information on the technical side of the system, drop into
 </section>
 
 <section>
+## What are spam waves? {#spam-waves}
+
+Spam waves are a tool that [metasmoke admins](https://charcoal-se.org/smokey/Privileges#admin-ms) have to set SmokeDetector to immediately cast any number of autoflags on detected posts matching pre-set criteria. That includes enough autoflags to immediately delete the post without requiring users to cast flags manually. This feature is separate from blacklisted/watched keywords - an admin must manually configure it in metasmoke.
+
+Additionally, SmokeDetector may use flags from _any_ user account with flagging enabled in metasmoke, regardless of the account’s autoflagging configuration (if any). At this time, it is not possible to opt out of this.
+
+If you wish to suggest a new spam wave, ping Makyen or another metasmoke admin for further information on how to proceed. Note that approval from a CM is required for unilateral deletion of posts matching specific criteria. Approval from site moderators is also acceptable for raising flags above the "normal" baseline. This tool is reserved for situations involving a severe influx of spam or extremely abusive content.
+</section>
+
+<section>
 ## More information {#more-info}
 
  - metasmoke has a [flagging dashboard](https://metasmoke.erwaysoftware.com/flagging)


### PR DESCRIPTION
This PR adds information on spam waves to the Charcoal Wiki page on autoflagging. Just so you know, I have **not** tested this change locally, so merge at your own risk. I don't anticipate it breaking anything, though, as what I added was very similar (in terms of markup) to the existing content on the page.