### PR TITLE
Address some bugs related to search

### DIFF
--- a/_assets/js/search.coffee
+++ b/_assets/js/search.coffee
@@ -47,7 +47,7 @@ $(window).on 'turbolinks:load', ->
         subsection = ''
         header = getHeader(suggestion._highlightResult) || getHeader(suggestion)
         if header
-          subsection = "<small>\xA7 #{escapeHTML(header.value ? header)}</small>"
+          subsection = "<small>\xA7 #{header.value ? header}</small>"
 
 
         """

--- a/_assets/js/search.coffee
+++ b/_assets/js/search.coffee
@@ -69,9 +69,9 @@ $(window).on 'turbolinks:load', ->
     if @searchConfig.baseUrl
       url = @searchConfig.baseUrl + url
 
-    if css_selector[0] == '#'
+    if css_selector && css_selector[0] == '#'
       url += css_selector
-    else if css_selector_parent[0] == '#'
+    else if css_selector_parent && css_selector_parent[0] == '#'
       url += css_selector_parent
 
     Turbolinks.visit(url)

--- a/_assets/js/search.coffee
+++ b/_assets/js/search.coffee
@@ -56,7 +56,7 @@ $(window).on 'turbolinks:load', ->
             #{suggestion._highlightResult.title?.value ? escapeHTML(suggestion.title ? 'Home')}
             #{subsection}
           </strong><br>
-          <small>#{suggestion._highlightResult.text?.value ? escapeHTML(suggestion.text)}</small><br>
+          #{if suggestion.excerpt_text then "<small>#{suggestion.excerpt_text}</small><br>" else ""}
             <small class="aa-link">#{resolve escapeHTML suggestion.url}</small>
         </p>
         """


### PR DESCRIPTION
- Fixes `undefined` in search results.
- Makes results clickable.
- Does not show unescaped HTML to the user.

Before:

![image](https://github.com/user-attachments/assets/dbdc9f44-075a-4b10-bd25-137b6bbb345a)

After:

![image](https://github.com/user-attachments/assets/5f76c890-6e87-4889-8425-d67c96075468)

