### PR TITLE
Added a new watch menu under training to explain the process of adding a watched item to SmokeDetector

### DIFF
--- a/training/autoflagging.md
+++ b/training/autoflagging.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# 5. Autoflagging
+# 6. Autoflagging
 In January 2017, we started [automatically flagging spam][meta] through metasmoke. This page
 details that system.
 

--- a/training/blacklister.md
+++ b/training/blacklister.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# 7. Further Privileges: Blacklister
+# 8. Further Privileges: Blacklister
 When you've been working within Charcoal for a while, there are further levels of privileges
 that you may be interested in getting. One of these is blacklister (formerly known as "code admin"),
 which deals with our blacklisting systems.

--- a/training/core.md
+++ b/training/core.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# 6. Further Privileges: Core
+# 8. Further Privileges: Core
 When you've been working within Charcoal for a while, there are further levels of privileges
 that you may be interested in getting. For most people, the first of these is Core.
 

--- a/training/core.md
+++ b/training/core.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# 8. Further Privileges: Core
+# 7. Further Privileges: Core
 When you've been working within Charcoal for a while, there are further levels of privileges
 that you may be interested in getting. For most people, the first of these is Core.
 

--- a/training/index.md
+++ b/training/index.md
@@ -21,13 +21,13 @@ sure we're all doing it consistently.
 ## Introduction Index
 This is a list of all the documents in this series. Start at the top and work your way down.
 
-1. [What's Charcoal?][/training/charcoal]
-2. [What's spam?][/training/spam]
-3. [When do you watch spam?][/training/watch]
-4. [Privileges][/training/privileges]
-5. [Handling reports][/training/reports]
-6. [Autoflagging][/training/autoflagging]
-7. [Further privileges: Core][/training/core]
-8. [Further privileges: Blacklister][/training/blacklister]
+1. [What's Charcoal?](/training/charcoal)
+2. [What's spam?](/training/spam)
+3. [When do you watch spam?](/training/watch)
+4. [Privileges](/training/privileges)
+5. [Handling reports](/training/reports)
+6. [Autoflagging](/training/autoflagging)
+7. [Further privileges: Core](/training/core)
+8. [Further privileges: Blacklister](/training/blacklister)
 
 [hq]: https://chat.stackexchange.com/rooms/11540/charcoal-hq

--- a/training/index.md
+++ b/training/index.md
@@ -21,21 +21,13 @@ sure we're all doing it consistently.
 ## Introduction Index
 This is a list of all the documents in this series. Start at the top and work your way down.
 
-1. [What's Charcoal?][1]
-2. [What's spam?][2]
-3. [When do you watch spam?][3]
-4. [Privileges][4]
-5. [Handling reports][5]
-6. [Autoflagging][6]
-7. [Further privileges: Core][7]
-8. [Further privileges: Blacklister][8]
+1. [What's Charcoal?][/training/charcoal]
+2. [What's spam?][/training/spam]
+3. [When do you watch spam?][/training/watch]
+4. [Privileges][/training/privileges]
+5. [Handling reports][/training/reports]
+6. [Autoflagging][/training/autoflagging]
+7. [Further privileges: Core][/training/core]
+8. [Further privileges: Blacklister][/training/blacklister]
 
 [hq]: https://chat.stackexchange.com/rooms/11540/charcoal-hq
-[1]: /training/charcoal
-[2]: /training/spam
-[3]: /training/watch
-[4]: /training/privileges
-[5]: /training/reports
-[6]: /training/autoflagging
-[7]: /training/core
-[8]: /training/blacklister

--- a/training/index.md
+++ b/training/index.md
@@ -21,14 +21,14 @@ sure we're all doing it consistently.
 ## Introduction Index
 This is a list of all the documents in this series. Start at the top and work your way down.
 
- - [What's Charcoal?][1]
- - [What's spam?][2]
- - [When do you watch spam?][3]
- - [Privileges][4]
- - [Handling reports][5]
- - [Autoflagging][6]
- - [Further privileges: Core][7]
- - [Further privileges: Blacklister][8]
+1. [What's Charcoal?][1]
+2. [What's spam?][2]
+3. [When do you watch spam?][3]
+4. [Privileges][4]
+5. [Handling reports][5]
+6. [Autoflagging][6]
+7. [Further privileges: Core][7]
+8. [Further privileges: Blacklister][8]
 
 [hq]: https://chat.stackexchange.com/rooms/11540/charcoal-hq
 [1]: /training/charcoal

--- a/training/index.md
+++ b/training/index.md
@@ -23,17 +23,19 @@ This is a list of all the documents in this series. Start at the top and work yo
 
  - [What's Charcoal?][1]
  - [What's spam?][2]
- - [Privileges][3]
- - [Handling reports][4]
- - [Autoflagging][5]
+ - [When do you watch spam?][3]
+ - [Privileges][4]
+ - [Handling reports][5]
+ - [Autoflagging][6]
  - [Further privileges: Core][7]
- - [Further privileges: Blacklister][6]
+ - [Further privileges: Blacklister][8]
 
 [hq]: https://chat.stackexchange.com/rooms/11540/charcoal-hq
 [1]: /training/charcoal
 [2]: /training/spam
-[3]: /training/privileges
-[4]: /training/reports
-[5]: /training/autoflagging
-[6]: /training/blacklister
+[3]: /training/watch
+[4]: /training/privileges
+[5]: /training/reports
+[6]: /training/autoflagging
 [7]: /training/core
+[8]: /training/blacklister

--- a/training/privileges.md
+++ b/training/privileges.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# 3. Privileges
+# 4. Privileges
 SmokeDetector has a limited number of [commands that are available for anyone to use][commandsNonPriv]. However,
 all its major functionality requires additional "privileges" to use. Being a privileged user
 means your user ID has been added to a list in SmokeDetector's code, which entitles you to

--- a/training/reports.md
+++ b/training/reports.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# 4. Handling reports
+# 5. Handling reports
 When a report comes into Charcoal HQ, there are two major things we need to do with it: flag
 and feedback.
 

--- a/training/spam.md
+++ b/training/spam.md
@@ -86,12 +86,12 @@ As always, use your best judgment, and ask if you're not sure.
 
 -----
 
-[Next: Privileges][3]
+[Next: When to watch spam?][3]
 
 [Return to Introduction Index][8]
 
 
 [def]: https://meta.stackexchange.com/q/58032
 [post]: https://metasmoke.erwaysoftware.com/post/108626
-[3]: /training/privileges
+[3]: /training/watch
 [8]: /training/index

--- a/training/watch.md
+++ b/training/watch.md
@@ -42,7 +42,7 @@ A bookmarklet is just a normal browser bookmark, where you add javascript code t
 then execute the code when you click the bookmark. Copy the javascript code and paste it
 into the URL field and save it, then you should be good to go.
 
-[List of bookmarklets](https://charcoal-se.org/smokey/Bookmarklets).
+[List of bookmarklets](https://charcoal-se.org/bookmarklets/).
 
 -----
 

--- a/training/watch.md
+++ b/training/watch.md
@@ -2,10 +2,12 @@
 ---
 
 # 3. When do you watch spam?
-Adding websites and keywords to be watched by SmokeDetector is a big part of being a privileged
-user on Charcoal. Unless a post is ***obvious*** spam, it can sometimes be a bit overwhelming to
-keep up with new software terms, libraries and projects (nuget, chocolatey, mustache, etc.) and
-know what is legit and what is not. We recommend doing a bit of research before you add a watch.
+Adding websites and keywords to SmokeDetector's watchlists is a big part of being a privileged
+user on Charcoal.
+
+Unless a post is ***obvious*** spam, it can sometimes be a bit overwhelming to detect what is a 
+legit post and what is not. After you've checked a post, determined that it's spam and found the text
+or website you want SmokeDetector to watch, we recommend doing a bit of research before adding it.
 
  - **Search** for the URL or keyword on [Stack Exchange](https://stackexchange.com/)
    - Use `url:example.com` in the search bar to find all questions and answers that have that website
@@ -15,9 +17,38 @@ know what is legit and what is not. We recommend doing a bit of research before 
      quotation marks. Example: `"key word"` and `"more words to search for"`. In this way it will
      only show results for the actual text you search for. Stack Exchange will otherwise show results
      for each searched word and this will typically return too many hits.
+     You can also use `code:keyword` to search for text that is hidden in a code snippet.
+ - **Search** [metasmoke](https://metasmoke.erwaysoftware.com/search) to see if anything already exist.
+   Maybe there's a lot of false positives, which would mean, that it shouldn't be added to the watchlist.
+   Metasmoke can be a bit complicated, but it can also be the best tool to find posts reported by
+   SmokeDetector. If you are good at regex it can be an advantage.
+   - Select `regex` in title, body and username. Now select `Use OR for text search (uses AND by default)`.
+     Enclose the text or URL you want to search for with `\b` and remember to escape functional regex
+     characters (`.` `()` `[]` etc.). You need to exclude `www.` from any URLs.
+     Example: Enter `\bsocket\.io\b` in title, body and username. It will now search for posts that
+     contain `socket.io` in either one or all of those fields. This broad search will make sure it catches
+     posts where spammers, for instance, have added a URL to only the title or maybe even in their username.
  - **Check** [open pull requests](https://github.com/Charcoal-SE/SmokeDetector/pulls) on SmokeDetector
    Github. The watch you want to add might already be queued for approval. It's always a good idea to
    check and make sure it's not a duplicate.
+
+## Bookmarklets
+To make life a bit easier, some users have made bookmarklets, that can do all the searching for you. Just
+select and mark the text you want to search for in a report from SmokeDetector and then click the
+bookmarklet. Depending on the version you choose to use, a new window will open in your browser and
+automatically do the search for you.
+
+A bookmarklet is just a normal browser bookmark, where you add javascript code to the URL field. This will
+then execute the code when you click the bookmark. When you copy the javascript code in the links below
+it's important to convert it first to one line so that it can be pasted into the URL field.
+
+List of bookmarklets:
+ - **Makyen** [Link](https://chat.stackexchange.com/rooms/11540/conversation/bookmarklets-for-searching-ms-for-blacklisted-expressions)
+   - The general bookmarklet for searching on metasmoke is the third one called **For blacklisted websites**.
+ - **Ryan M** [Link](https://gist.github.com/ThatRyanPerson/c3d50439e41f5e19b2b4a51c5f8f88a9)
+   - This one will search both metasmoke, but will also open three additional windows that searches
+     Stack Exchange with all the proper keywords and formatting. It uses optimized regex for metasmoke
+     to minimize load.
 
 -----
 

--- a/training/watch.md
+++ b/training/watch.md
@@ -39,8 +39,8 @@ bookmarklet. Depending on the version you choose to use, a new window will open 
 automatically do the search for you.
 
 A bookmarklet is just a normal browser bookmark, where you add javascript code to the URL field. This will
-then execute the code when you click the bookmark. When you copy the javascript code in the links below
-it's important to convert it first to one line so that it can be pasted into the URL field.
+then execute the code when you click the bookmark. Copy the javascript code in the links below and paste it
+into the URL field, then you should be good to go.
 
 List of bookmarklets:
  - **Makyen** [Link](https://chat.stackexchange.com/rooms/11540/conversation/bookmarklets-for-searching-ms-for-blacklisted-expressions)

--- a/training/watch.md
+++ b/training/watch.md
@@ -36,19 +36,13 @@ or website you want SmokeDetector to watch, we recommend doing a bit of research
 To make life a bit easier, some users have made bookmarklets, that can do all the searching for you. Just
 select and mark the text you want to search for in a report from SmokeDetector and then click the
 bookmarklet. Depending on the version you choose to use, a new window will open in your browser and
-automatically do the search for you.
+automatically do the search for you (you might need to accept popups before the window open).
 
 A bookmarklet is just a normal browser bookmark, where you add javascript code to the URL field. This will
-then execute the code when you click the bookmark. Copy the javascript code in the links below and paste it
-into the URL field, then you should be good to go.
+then execute the code when you click the bookmark. Copy the javascript code and paste it
+into the URL field and save it, then you should be good to go.
 
-List of bookmarklets:
- - **Makyen** [Link](https://chat.stackexchange.com/rooms/11540/conversation/bookmarklets-for-searching-ms-for-blacklisted-expressions)
-   - The general bookmarklet for searching on metasmoke is the third one called **For blacklisted websites**.
- - **Ryan M** [Link](https://gist.github.com/ThatRyanPerson/c3d50439e41f5e19b2b4a51c5f8f88a9)
-   - This one will search both metasmoke, but will also open three additional windows that searches
-     Stack Exchange with all the proper keywords and formatting. It uses optimized regex for metasmoke
-     to minimize load.
+[List of bookmarklets](https://charcoal-se.org/smokey/Bookmarklets).
 
 -----
 

--- a/training/watch.md
+++ b/training/watch.md
@@ -1,0 +1,29 @@
+---
+---
+
+# 3. When do you watch spam?
+Adding websites and keywords to be watched by SmokeDetector is a big part of being a privileged
+user on Charcoal. Unless a post is ***obvious*** spam, it can sometimes be a bit overwhelming to
+keep up with new software terms, libraries and projects (nuget, chocolatey, mustache, etc.) and
+know what is legit and what is not. We recommend doing a bit of research before you add a watch.
+
+ - **Search** for the URL or keyword on [Stack Exchange](https://stackexchange.com/)
+   - Use `url:example.com` in the search bar to find all questions and answers that has that website
+     in them. Check how many hits comes up and if it's only the spam and 2-3 other posts it will
+     typically be OK do add it.
+   - Keywords can be searched just like normal text, but multiple keywords should be enclosed in
+     quotation marks. Example: `"key word"` and `"more words to search for"`. In this way it will
+     only show results for the actual text you search for. Stack Exchange will otherwise show results
+     for each searched word and this will typically return too many hits.
+ - **Check** [open pull requests](https://github.com/Charcoal-SE/SmokeDetector/pulls) on SmokeDetector
+   Github. The watch you want to add might already be queued for approval. It's always a good idea to
+   check and make sure it's not a duplicate.
+
+-----
+
+[Next: Privileges][3]
+
+[Return to Introduction Index][8]
+
+[3]: /training/privileges
+[8]: /training/index

--- a/training/watch.md
+++ b/training/watch.md
@@ -8,9 +8,9 @@ keep up with new software terms, libraries and projects (nuget, chocolatey, must
 know what is legit and what is not. We recommend doing a bit of research before you add a watch.
 
  - **Search** for the URL or keyword on [Stack Exchange](https://stackexchange.com/)
-   - Use `url:example.com` in the search bar to find all questions and answers that has that website
-     in them. Check how many hits comes up and if it's only the spam and 2-3 other posts it will
-     typically be OK do add it.
+   - Use `url:example.com` in the search bar to find all questions and answers that have that website
+     in them. Check how many hits come up and if it's only the spam and 2-3 other posts it will
+     typically be OK to add it.
    - Keywords can be searched just like normal text, but multiple keywords should be enclosed in
      quotation marks. Example: `"key word"` and `"more words to search for"`. In this way it will
      only show results for the actual text you search for. Stack Exchange will otherwise show results


### PR DESCRIPTION
As I've discussed with several users in Charcoal, we thought it would be a good idea to explain what to do before adding watched items to SmokeDetector. I have changed the menu form from point based to number based in order to reflect the order in which it should be read. I have also changed the title page numbers and next link on all the current menu items so that it fits the correct order. 

watch.md is new and I have written a short helping text what users should do before adding urls etc. to Smokey.