### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - name: Bundler cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-bundler-${{ hashFiles('Gemfile.lock') }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'sprockets-es6'
 gem 'uglifier'
 
 group :jekyll_plugins do
-  gem 'github-pages'
+  gem 'github-pages', '~> 231'
   gem 'jekyll-assets', '~> 2.4'
   gem 'jekyll-algolia', '~> 1.0'
 end

--- a/script/install
+++ b/script/install
@@ -12,4 +12,5 @@ while [ $# -ne 0 ]; do
   shift
 done
 
-bundle install --path=vendor/bundle
+bundle config set --local path 'vendor/bundle'
+bundle install

--- a/script/serve
+++ b/script/serve
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-bundle exec jekyll serve --incremental -L
+bundle exec jekyll serve --incremental -l


### PR DESCRIPTION
- Bumps GitHub Actions dependencies.
- Uses github-pages v231 which is compatible with Ruby 2.7.
- Corrects invalid `-L` option to `jekyll serve` (correct is `-l`).
- Addresses a deprecation message from bundler.